### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/assets/stylesheets/orders/reset.css
+++ b/app/assets/stylesheets/orders/reset.css
@@ -1,0 +1,126 @@
+/*!
+ * YUI 3.5.0 - reset.css (http://developer.yahoo.com/yui/3/cssreset/)
+ * http://cssreset.com
+ * Copyright 2012 Yahoo! Inc. All rights reserved.
+ * http://yuilibrary.com/license/
+ */
+/*
+    TODO will need to remove settings on HTML since we can't namespace it.
+    TODO with the prefix, should I group by selector or property for weight savings?
+*/
+html{
+  color:#000;
+  background:#FFF;
+}
+/*
+  TODO remove settings on BODY since we can't namespace it.
+*/
+/*
+  TODO test putting a class on HEAD.
+      - Fails on FF.
+*/
+body,
+div,
+dl,
+dt,
+dd,
+ul,
+ol,
+li,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+pre,
+code,
+form,
+fieldset,
+legend,
+input,
+textarea,
+p,
+blockquote,
+th,
+td {
+  margin:0;
+  padding:0;
+}
+table {
+  border-collapse:collapse;
+  border-spacing:0;
+}
+fieldset,
+img {
+  border:0;
+}
+/*
+  TODO think about hanlding inheritence differently, maybe letting IE6 fail a bit...
+*/
+address,
+caption,
+cite,
+code,
+dfn,
+em,
+strong,
+th,
+var {
+  font-style:normal;
+  font-weight:normal;
+}
+
+ol,
+ul {
+  list-style:none;
+}
+
+caption,
+th {
+  text-align:left;
+}
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-size:100%;
+  font-weight:normal;
+}
+q:before,
+q:after {
+  content:'';
+}
+abbr,
+acronym {
+  border:0;
+  font-variant:normal;
+}
+/* to preserve line-height and selector appearance */
+sup {
+  vertical-align:text-top;
+}
+sub {
+  vertical-align:text-bottom;
+}
+input,
+textarea,
+select {
+  font-family:inherit;
+  font-size:inherit;
+  font-weight:inherit;
+}
+/*to enable resizing for IE*/
+input,
+textarea,
+select {
+  *font-size:100%;
+}
+/*because legend doesn't inherit in IE */
+legend {
+  color:#000;
+}
+/* YUI CSS Detection Stamp */
+#yui3-css-stamp.cssreset { display: none; }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: :new
 
   def index
-    # @item = Item.order('created_at DESC')
+    @items = Item.order('created_at DESC')
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,8 +129,8 @@
     <ul class='item-lists'>
 
       <% if @items.present? %>
+      <% @items.each do |item| %>
       <li class='list'>
-        <% @items.each do |item| %>
         <div class='item-img-content'>
           <%= link_to image_tag(item.image, class: "item-img") %>
 
@@ -153,8 +153,8 @@
             </div>
           </div>
         </div>
-        <% end %>
       </li>
+      <% end %>
       <% else %>
       <li class='list'>
         <%= link_to '#' do %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -131,6 +131,7 @@
       <% if @items.present? %>
       <% @items.each do |item| %>
       <li class='list'>
+        <%= link_to "#" do %>
         <div class='item-img-content'>
           <%= link_to image_tag(item.image, class: "item-img") %>
 
@@ -153,6 +154,7 @@
             </div>
           </div>
         </div>
+        <% end %>
       </li>
       <% end %>
       <% else %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,11 +128,11 @@
     </div>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% if @items.present? %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <% @items.each do |item| %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= link_to image_tag(item.image, class: "item-img") %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
@@ -143,10 +143,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= link_to item.item_name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= link_to item.price %>円<br><%= link_to item.shipping_charge.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -155,10 +155,7 @@
         </div>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+      <% else %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -176,8 +173,7 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -133,7 +133,7 @@
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= link_to image_tag(item.image, class: "item-img") %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
@@ -144,10 +144,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= link_to item.item_name %>
+            <%= item.item_name %>
           </h3>
           <div class='item-price'>
-            <span><%= link_to item.price %>円<br><%= link_to item.shipping_charge.name %></span>
+            <span><%= item.price %>円<br><%= link_to item.shipping_charge.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -131,12 +131,11 @@ RSpec.describe Item, type: :model do
         expect(@item.errors.full_messages).to include("Shipping days can't be blank")
       end
 
-      it "user_idが紐づいてなければ登録できない" do
+      it 'user_idが紐づいてなければ登録できない' do
         @item.user = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("User must exist")
+        expect(@item.errors.full_messages).to include('User must exist')
       end
-
     end
   end
 end


### PR DESCRIPTION
#What
・商品一覧表示機能を実装する。

「確認動画」

・商品のデータがない場合は、ダミー商品が表示されている動画
　（*sequel proのテーブルを直接削除した後リロードしています）
　https://gyazo.com/17ea96f62ede4dabf41c6cf4e20bd59e
　
・商品のデータがある場合は、商品が一覧で表示されている動画
　https://gyazo.com/9d39d3e11c5e19ddae1fb3b87c1ed954


#Why
商品一覧表示機能を実装するため。